### PR TITLE
Add long_description_content_type to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
 license = Apache 2.0
 long_description = file: README.md
+long_description_content_type = text/markdown
 name = dwave-scikit-learn-plugin
 project_urls =
     Changes = https://github.com/dwavesystems/dwave-scikit-learn-plugin/releases


### PR DESCRIPTION
Fix for the pypi upload. I did the [0.0.1](https://github.com/dwavesystems/dwave-scikit-learn-plugin/releases/tag/0.0.1) deploy by SSHing into the circle-ci job and editing the file manually. This should fix it for future deploys.