### PR TITLE
Update objective computation: multiply quadratic biases with (1-alpha)

### DIFF
--- a/releasenotes/notes/algorithm-update-d73cd4f7c854a8b3.yaml
+++ b/releasenotes/notes/algorithm-update-d73cd4f7c854a8b3.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Multiply off-diagonal terms of the correlation matrix with 1-alpha.


### PR DESCRIPTION
The current implementation is not consistent with the documentation, which states that:

```python
   """
    ``alpha=1`` places the maximum weight on the quality of the features,
    and therefore will be equivalent to using
    :class:`sklearn.feature_selection.SelectKBest`.
   """
```
To make the docs consistent with the code, we change the code and multiply the off-diagonal terms of the objective matrix (or quadratic biases) with `1-alpha`