### PR TITLE
Fix NumPy triu and other typing errors

### DIFF
--- a/dwave/plugins/sklearn/transformers.py
+++ b/dwave/plugins/sklearn/transformers.py
@@ -243,7 +243,6 @@ class SelectFromQuadraticModel(SelectorMixin, BaseEstimator):
         linear = np.zeros(len(feat_corr[0]))
 
         # numpy will automatically go element-by-element in the arrays
-        # Calculate linear coefficients using pure NumPy math first
         linear += -1.0 * label_corr * alpha * num_features
 
         # if must choose exact number of desired features

--- a/dwave/plugins/sklearn/transformers.py
+++ b/dwave/plugins/sklearn/transformers.py
@@ -221,11 +221,8 @@ class SelectFromQuadraticModel(SelectorMixin, BaseEstimator):
         # take last element in every row
         label_corr = np.array(correlations[:-1,-1])
 
-        # Make a constant node in order to splice and use in objective
-        nl_corr = nl.constant(feat_corr)
-
         # extract upper triangle, excluding diagonal. Flatten into 1D array
-        C = np.triu(nl_corr, k=1).flatten()
+        C = np.triu(feat_corr, k=1).flatten()
 
         # generate all column and row indices
         quad_col = np.tile(np.arange(total_num_features), total_num_features)
@@ -246,7 +243,8 @@ class SelectFromQuadraticModel(SelectorMixin, BaseEstimator):
         linear = np.zeros(len(feat_corr[0]))
 
         # numpy will automatically go element-by-element in the arrays
-        linear += nl.constant(-1.0 * label_corr * alpha * num_features)
+        # Calculate linear coefficients using pure NumPy math first
+        linear += -1.0 * label_corr * alpha * num_features
 
         # if must choose exact number of desired features
         if strict:

--- a/releasenotes/notes/Fix-np.triu-error-and-other-typing-errors-b3a5a8c6d4a21887.yaml
+++ b/releasenotes/notes/Fix-np.triu-error-and-other-typing-errors-b3a5a8c6d4a21887.yaml
@@ -1,14 +1,4 @@
 ---
-prelude: >
-    This release addresses compatibility issues with newer versions of `dwave-optimization`
-    and `numpy`, specifically fixing crashes when using the nonlinear (`nl`) solver
-    in `SelectFromQuadraticModel`.
-features: []
-issues: []
-upgrade: []
-deprecations: []
-critical: []
-security: []
 fixes:
   - |
     Fixed a `TypeError` when using `SelectFromQuadraticModel(solver="nl")` caused by
@@ -19,4 +9,3 @@ fixes:
     during nonlinear model creation. Unnecessary `nl.constant` wrappers were removed
     to ensure linear coefficients and quadratic indices are passed as native NumPy
     arrays, which prevents arithmetic type mismatches and buffer access issues.
-other: []

--- a/releasenotes/notes/Fix-np.triu-error-and-other-typing-errors-b3a5a8c6d4a21887.yaml
+++ b/releasenotes/notes/Fix-np.triu-error-and-other-typing-errors-b3a5a8c6d4a21887.yaml
@@ -1,0 +1,22 @@
+---
+prelude: >
+    This release addresses compatibility issues with newer versions of `dwave-optimization`
+    and `numpy`, specifically fixing crashes when using the nonlinear (`nl`) solver
+    in `SelectFromQuadraticModel`.
+features: []
+issues: []
+upgrade: []
+deprecations: []
+critical: []
+security: []
+fixes:
+  - |
+    Fixed a `TypeError` when using `SelectFromQuadraticModel(solver="nl")` caused by
+    `numpy.triu` failing on D-Wave `Constant` objects. The upper triangular matrix is now
+    computed using standard NumPy arrays before being converted to optimization symbols.
+  - |
+    Resolved `ValueError: buffer source array is read-only` and other typing errors
+    during nonlinear model creation. Unnecessary `nl.constant` wrappers were removed
+    to ensure linear coefficients and quadratic indices are passed as native NumPy
+    arrays, which prevents arithmetic type mismatches and buffer access issues.
+other: []


### PR DESCRIPTION
This Pull Request mainly addresses
- a compatibility issue between `dwave-scikit-learn-plugin` and `np.triu`;
- `nl.constant` typing issues.